### PR TITLE
feat: add Docker container build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-RUN mkdir /app
 WORKDIR /app
-ADD . /app/
+ADD ./docker/docker-setup.sh ./Makefile ./README.md /app/
+ADD ./src /app/src/
 RUN /bin/bash /app/docker-setup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+RUN mkdir /app
+WORKDIR /app
+ADD . /app/
+RUN /bin/bash /app/docker-setup.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ Cr4ckm3 is a small cracking game in which you search for password by using "unus
 
 The exercises are pretty easy, you need to use tools like `strings`, `strace`, `gdb`, `gprof` or `g++`/`clang++` sanitizers.
 
-**NOTE: This should REALLY be a Docker container. If you mind to create one, simply create a Pull Request! ;)**
+# Docker build instructions
+
+To make sure you have all the right versions of all the required tools, there is a Docker build file. To build the Docker image and play the game, run the following:
+```bash
+docker build -t crackme .
+docker run -it crackme
+cd crackme/
+ls # you'll see all the challenges here
+```
 
 # Rules
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ The exercises are pretty easy, you need to use tools like `strings`, `strace`, `
 
 # Docker build instructions
 
-To make sure you have all the right versions of all the required tools, there is a Docker build file. To build the Docker image and play the game, run the following:
+To make sure you have all the right versions of all the required tools, there is a Docker build file. To build the Docker image:
 ```bash
-docker build -t crackme .
-docker run -it crackme
+bash ./docker/build.sh
+```
+
+... and play the game, run the following:
+```bash
+bash ./docker/run.sh
+# now you're in the container
+cat README.md # to see instructions
 cd crackme/
 ls # you'll see all the challenges here
 ```

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+apt-get update
+apt-get --assume-yes install \
+  wget \
+  unzip \
+  gcc \
+  python3 \
+  g++ \
+  gdb \
+  strace \
+  clang \
+  make
+# FIXME include any other required tools
+make
+apt-get --assume-yes purge \
+  wget \
+  unzip
+apt-get --assume-yes autoremove
+apt-get --assume-yes clean
+rm -rf \
+ /var/lib/apt/lists/* \
+ /tmp/* \
+ /var/tmp/*
+rm -r \
+ docker-setup.sh \
+ Makefile \
+ Dockerfile \
+ src

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# builds the docker container
+cd `dirname "$0"`/..
+docker build -t disconnect3d/crackme .

--- a/docker/docker-setup.sh
+++ b/docker/docker-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# script to be run inside the docker container during build, don't run this directly
 set -e
 apt-get update
 apt-get --assume-yes install \
@@ -25,5 +26,4 @@ rm -rf \
 rm -r \
  docker-setup.sh \
  Makefile \
- Dockerfile \
  src

--- a/docker/docker-setup.sh
+++ b/docker/docker-setup.sh
@@ -11,9 +11,15 @@ apt-get --assume-yes install \
   gdb \
   strace \
   clang \
-  make
-# FIXME include any other required tools
+  make \
+  vim
+
 make
+
+# for the fork challenge
+cd crackme/
+ln -s . crackme
+
 apt-get --assume-yes purge \
   wget \
   unzip
@@ -22,8 +28,7 @@ apt-get --assume-yes clean
 rm -rf \
  /var/lib/apt/lists/* \
  /tmp/* \
- /var/tmp/*
-rm -r \
+ /var/tmp/* \
  docker-setup.sh \
  Makefile \
  src

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# runs the docker container
+cd `dirname "$0"`/..
+# thanks https://github.com/moby/moby/issues/20064#issuecomment-291095117 for security tip
+docker run \
+  --rm \
+  -it \
+  --security-opt seccomp:unconfined \
+  disconnect3d/crackme


### PR DESCRIPTION
I've added a build script to make a Docker container. I haven't actually done the challenges yet so I'm not 100% if it's got everything that's needed (and the right versions) but if/when I get a chance to do them, I'll confirm that. I thought I'd send the PR now though so others can get some use.

I've added instructions on how to build in the README but if you auto build the docker container on Docker cloud, you can just get people to pull the image from the main registry rather than building locally.

I decided to have the Docker build call `make` so it's all ready to go. This means the src/ isn't there, so no cheating. But it means your message at the end of `make` probably won't be seen. I was thinking of doing a `make | tee make.log` in the docker build and maybe even doing a `cat` of the log when you run the Docker image so you see the message on startup.